### PR TITLE
fix prefetch error when current model has a m2m relation to grouper field - v2

### DIFF
--- a/djangocms_versioning/monkeypatch/extensions.py
+++ b/djangocms_versioning/monkeypatch/extensions.py
@@ -13,7 +13,7 @@ from djangocms_versioning.handlers import _update_modified
 
 def _copy_title_extensions(self, source_page, target_page, language, clone=False):
     """
-    djangocms-cms/extensions/admin.py, last changed in: divio/django-cms@2894ae8
+    djangocms-cms/extensions/admin.py, last changed in: django-cms/django-cms@2894ae8
 
     The existing method ExtensionPool._copy_title_extensions will only ever
     get published versions, we change the queries to get the latest draft version

--- a/djangocms_versioning/test_utils/polls/cms_plugins.py
+++ b/djangocms_versioning/test_utils/polls/cms_plugins.py
@@ -1,7 +1,7 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from .models import PollPlugin as Poll
+from .models import PollManyPlugin as PollMany, PollPlugin as Poll
 
 
 @plugin_pool.register_plugin
@@ -10,3 +10,11 @@ class PollPlugin(CMSPluginBase):
     name = "Poll"
     allow_children = True
     render_template = "polls/poll.html"
+
+
+@plugin_pool.register_plugin
+class PollManyPlugin(CMSPluginBase):
+    model = PollMany
+    name = "PollMany"
+    allow_children = True
+    render_template = "polls/polls.html"

--- a/djangocms_versioning/test_utils/polls/models.py
+++ b/djangocms_versioning/test_utils/polls/models.py
@@ -39,3 +39,10 @@ class PollPlugin(CMSPlugin):
 
     def __str__(self):
         return str(self.poll)
+
+
+class PollManyPlugin(CMSPlugin):
+    polls = models.ManyToManyField(Poll, blank=True)
+
+    def __str__(self):
+        return ''

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -57,7 +57,7 @@ class MonkeypatchExtensionTestCase(CMSTestCase):
         )
         # No asserts, this test originally failed because the versioned manager was called
         # in copy_extensions, now we call the original manager instead
-        # https://github.com/divio/djangocms-versioning/pull/201/files#diff-fc33dd7b5aa9b1645545cf48dfc9b4ecR19
+        # https://github.com/django-cms/djangocms-versioning/pull/201/files#diff-fc33dd7b5aa9b1645545cf48dfc9b4ecR19
 
     def test_pagecontent_copy_method_creates_extension_title_extension_attached(self):
         """

--- a/tests/test_plugin_rendering.py
+++ b/tests/test_plugin_rendering.py
@@ -1,0 +1,70 @@
+from cms.api import add_plugin
+from cms.test_utils.testcases import CMSTestCase
+from cms.toolbar.toolbar import CMSToolbar
+
+from djangocms_versioning.plugin_rendering import VersionContentRenderer
+from djangocms_versioning.test_utils.factories import (
+    PageVersionFactory,
+    PlaceholderFactory,
+    PollVersionFactory,
+)
+
+
+class MonkeypatchTestCase(CMSTestCase):
+    def test_prefetch_versioned_m2m_objects(self):
+        '''
+        test model with manytomany field to grouper model
+        '''
+        request = self.get_request('/')
+        toolbar = CMSToolbar(request)
+        toolbar.edit_mode_active = True
+        request.toolbar = toolbar
+        context = {"request": request}
+        contentRenderer = VersionContentRenderer(request)
+
+        version = PageVersionFactory()
+        placeholder = PlaceholderFactory(source=version.content)
+        poll_version = PollVersionFactory(content__language='en')
+        poll = poll_version.content.poll
+
+        plugin = add_plugin(
+            placeholder, "PollManyPlugin", version.content.language
+        )
+
+        plugin.polls.add(poll)
+        plugin._prefetched_objects_cache = {}
+
+        with self.assertNumQueries(1):
+            contentRenderer.render_plugin(plugin, context)
+            for i in range(1000):
+                self.assertEqual(1, len(plugin.polls.all()))
+
+        with self.assertNumQueries(0):
+            self.assertEqual(1, len(plugin.polls.all()))
+
+        self.assertIsNotNone(plugin._prefetched_objects_cache)
+        self.assertIsNotNone(plugin._prefetched_objects_cache['polls'])
+        self.assertEqual(len(plugin._prefetched_objects_cache['polls']), 1)
+
+    def test_prefetch_versioned_m2o_objects(self):
+        '''
+        #test model with one foreign key to grouper model
+        '''
+        request = self.get_request('/')
+        toolbar = CMSToolbar(request)
+        toolbar.edit_mode_active = True
+        request.toolbar = toolbar
+        context = {"request": request}
+        contentRenderer = VersionContentRenderer(request)
+
+        version = PageVersionFactory()
+        placeholder = PlaceholderFactory(source=version.content)
+        poll_version = PollVersionFactory(content__language='en')
+        poll = poll_version.content.poll
+
+        plugin = add_plugin(
+            placeholder, "PollPlugin", version.content.language, poll=poll
+        )
+
+        contentRenderer.render_plugin(plugin, context)
+        self.assertIsNotNone(plugin.poll._prefetched_objects_cache)


### PR DESCRIPTION
based on djangocms-versioning 1.3.0

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
